### PR TITLE
Add missing URL protocol to telegram file posts

### DIFF
--- a/app/Notifications/NewsCreated.php
+++ b/app/Notifications/NewsCreated.php
@@ -67,6 +67,9 @@ class NewsCreated extends Notification implements ShouldQueue
         $url = 'https://abfaltersbach.at?newsID='.$notifiable->ID;
 
         if ($src = array_pop($match)) {
+            // Ensure src starts with https
+            $src = preg_replace('@^\/\/@', 'https://', $src);
+
             return TelegramFile::create()
                 ->to(config('services.telegram-bot-api.channel'))
                 ->content(implode("\n", [$title, $content]))


### PR DESCRIPTION
An issue occurred where images posted to telegram did not include the HTTPS protocol. A 400 Bad request was raised and the post was not sent.