### PR TITLE
chore: block major dependency updates in Dependabot and Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
       - "dependabot 🤖"
       - "dependencies"
       - "gh-actions"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -17,6 +20,21 @@ updates:
       - "dependabot 🤖"
       - "dependencies"
       - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/resources/easyadmin"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependabot 🤖"
+      - "dependencies"
+      - "npm"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -26,6 +44,9 @@ updates:
       - "dependabot 🤖"
       - "dependencies"
       - "composer"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -35,3 +56,6 @@ updates:
       - "dependabot 🤖"
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,10 @@
         {
             "updateTypes": ["minor", "patch", "pin", "digest"],
             "automerge": true
+        },
+        {
+            "updateTypes": ["major"],
+            "enabled": false
         }
     ],
     "schedule": ["after 10pm and before 5am on every weekday", "every weekend"],


### PR DESCRIPTION
## Summary
- Neither `.github/dependabot.yml` nor `.github/renovate.json` currently blocks major-version bumps — Renovate's config only skips *automerge* for majors (they still open as PRs), and Dependabot has no `ignore` rules at all. This is very likely how `vue` got bumped 2.x → `^3.0.0` in `resources/easyadmin` in a prior commit, without migrating the Vue-2-only ecosystem it depends on (`vuex`, `vue-router`, `vue-class-component`, `@coreui/vue`, `tinymce-vue`) — see #2192 for the resulting CI breakage and fix.
- Added `ignore: [{dependency-name: "*", update-types: ["version-update:semver-major"]}]` to every Dependabot ecosystem entry, including a new entry for `resources/easyadmin` (previously missing from the scheduled config entirely, even though it has its own `package.json`).
- Disabled Renovate's `major` update type via `packageRules`.

Note: no `Renovate` check currently appears on this repo's PRs, so `renovate.json` may be dormant config from an app that's no longer installed — fixed it anyway in case it's re-enabled later.

## How to test
No runtime behavior to test directly; verify by checking that future Dependabot PRs no longer include major-version bumps (e.g. `vue`, `axios`, `@sentry/*` major jumps), only minor/patch.