### PR TITLE
docs: point report to live Erklärung link, summarize check tools inline

### DIFF
--- a/docs/reports/abfaltersbach-2026-08-12.md
+++ b/docs/reports/abfaltersbach-2026-08-12.md
@@ -6,9 +6,12 @@
 Chromium, ergänzt um acht eigene Prüfmodule), keine manuelle Nachprüfung.
 
 Dieser Bericht ist die technische Grundlage für die
-[Erklärung zur Barrierefreiheit](../erklaerung/abfaltersbach.html). Was geprüft wurde und mit
-welcher Methode, steht in [`docs/pruefabdeckung.md`](../pruefabdeckung.md) und
-[`docs/research/automatisierung-offene-pruefungen.md`](../research/automatisierung-offene-pruefungen.md).
+[Erklärung zur Barrierefreiheit](https://abfaltersbach.at/barrierefreiheitserklaerung). Geprüft
+wurde mit axe-core (echtes Chromium, ein Ladezustand, ein Viewport 1280×900) sowie acht eigenen
+Prüfmodulen für das, was axe nicht abdeckt: Tastaturbedienung und Fokus, Kontrast in
+Interaktionszuständen, Reflow/Zoom/Textabstand, Formularstatik, Überschriftenstruktur,
+Alternativtext-Eignung, Medieninventar und Statusmeldungen. Jedes Modul meldet nur mechanisch
+entscheidbare Verstöße als Fehler; alles andere geht als `needsReview` an ein menschliches Urteil.
 **PDFs und Office-Dateien wurden in diesem Prüflauf nicht geprüft** (EN 301 549 Kapitel 10, Issue
 [#16](https://github.com/biegl/wcag-check/issues/16)) — die Amtstafel, die Rechnungsabschlüsse und
 die übrigen Dokumentenlisten der Website enthalten voraussichtlich Dokumente, für die keine
@@ -126,10 +129,9 @@ Erklärung zur Barrierefreiheit.
 
 ## Was nicht geprüft wurde
 
-- **PDFs und Office-Dateien** (EN 301 549 Kapitel 10) — auf Anweisung in diesem Prüflauf
-  ausgelassen. Die Website verlinkt Dokumente auf mindestens der Amtstafel und den
-  Rechnungsabschlüssen; ohne Prüfung kann für diese Dokumente weder Vereinbarkeit noch eine
-  Ausnahme belegt werden.
+- **PDFs und Office-Dateien** (EN 301 549 Kapitel 10). Die Website verlinkt Dokumente auf
+  mindestens der Amtstafel und den Rechnungsabschlüssen; ohne Prüfung kann für diese Dokumente
+  weder Vereinbarkeit noch eine Ausnahme belegt werden.
 - **Audiodeskription** (SC 1.2.3, 1.2.5) — die Website hat aktuell keine Video- oder
   Audio-Inhalte; das Medieninventar-Modul lief mit, fand aber nichts zu prüfen.
 - Alles, was nur durch Interaktion entsteht, die dieser Prüflauf bewusst nicht ausgelöst hat


### PR DESCRIPTION
## Summary
- Point the "Erklärung zur Barrierefreiheit" link in the audit report to the live page instead of the local build path
- Replace the reference to `docs/pruefabdeckung.md`/`docs/research/automatisierung-offene-pruefungen.md` (not present in this repo) with a short inline summary of the tools/modules used
- Drop the internal "auf Anweisung in diesem Prüflauf ausgelassen" note on skipped PDF/Office checks

## Test plan
- [ ] Read through `docs/reports/abfaltersbach-2026-08-12.md` and confirm the rendered link and summary read correctly